### PR TITLE
bio in frontmatter, better headings

### DIFF
--- a/public/content/fellowship/Abhishek/index.md
+++ b/public/content/fellowship/Abhishek/index.md
@@ -9,15 +9,15 @@ lat: 28.6139
 lon: 77.209
 image: /content/fellowship/Abhishek/abhishek-headshot.jpg
 description: Harvest-time loans for farmers in India
+bio: |
+  ## Abhishek Bhattacharya
+
+  Abhishek Bhattacharya is a co-founder at [Brú Finance](https://bru.finance/) . Brú Finance is a platform that aims to provide harvest-time loans for farmers in India. For his Fellowship project, Abhishek learned from the launch of Brú's platform to a public chain that utilizes decentralized liquidity for the farmers and explored what this system could look like on a global scale.
+
+  ### [Interview at Devcon6 2022](https://youtu.be/K18r8_mHS6E?si=a0pCIEZ1GHe3181d)
 tags:
   - defi
   - SEAsia
   - hidden
   - 2022-cohort-2
 ---
-
-## Abhishek Bhattacharya
-
-Abhishek Bhattacharya is a co-founder at [Brú Finance](https://bru.finance/) . Brú Finance is a platform that aims to provide harvest-time loans for farmers in India. For his Fellowship project, Abhishek learned from the launch of Brú's platform to a public chain that utilizes decentralized liquidity for the farmers and explored what this system could look like on a global scale.
-
-### [Interview at Devcon6 2022](https://youtu.be/K18r8_mHS6E?si=a0pCIEZ1GHe3181d)

--- a/public/content/fellowship/Benson/index.md
+++ b/public/content/fellowship/Benson/index.md
@@ -9,6 +9,10 @@ lon: 36.8219
 country: Kenya
 image: /content/fellowship/Benson/benson-headshot-logo.jpg
 description: Microinsurance products for small-scale farmers in Kenya in extreme weather events
+bio: |
+  ## Benson Njuguna
+
+  Benson Njuguna [(Acre Africa)](https://acreafrica.com/) worked to implement blockchain solutions to a microinsurance product that protects thousands of small-scale farmers in Kenya from extreme weather events. His project tested and showcased Ethereum's potential in enabling the viability and sustainability of products and services that target the bottom of the wealth pyramid. [Read more about Benson's work here.](https://blog.ethereum.org/2021/12/07/fellows-spotlight-on-kenya/)
 tags:
   - farmers
   - insurance
@@ -17,10 +21,6 @@ tags:
   - 2021-cohort-1
   - kenya
 ---
-
-## Benson Njuguna
-
-Benson Njuguna [(Acre Africa)](https://acreafrica.com/) worked to implement blockchain solutions to a microinsurance product that protects thousands of small-scale farmers in Kenya from extreme weather events. His project tested and showcased Ethereum’s potential in enabling the viability and sustainability of products and services that target the bottom of the wealth pyramid. [Read more about Benson's work here.](https://blog.ethereum.org/2021/12/07/fellows-spotlight-on-kenya/)
 
 ---
 

--- a/public/content/fellowship/Brian/index.md
+++ b/public/content/fellowship/Brian/index.md
@@ -9,6 +9,10 @@ lat: -6.2088
 lon: 106.8456
 image: /content/fellowship/Brian/brian-headshot.jpg
 description: Brian investigated the needs of web3 workers through Copra Finance, a startup that designs web3 financial products for working folks in Jakarta, Indonesia
+bio: |
+  ## Brian Limiardi
+
+  **Brian Limiardi** builds for financial inclusion in Indonesia as co-founder of [Copra](https://www.copra.finance/). While access to personal loans is available through banks, there are many contexts in which the only way to get a loan for business is through informal lenders (read: loan sharks). For folks who choose to work and invoice in cryptocurrency, access to even simple legacy financial tools like personal or small business loans can be an obstacle. For his Fellowship, Brian will focus on researching the needs and realities of the growing demographic of workers and small businesses who use crypto as a primary means of invoicing and bookkeeping.
 tags:
   - defi
   - NFT
@@ -16,10 +20,5 @@ tags:
   - 2023-cohort-3
 ---
 
-## Brian Limiardi
-
-**Brian Limiardi** builds for financial inclusion in Indonesia as co-founder of [Copra](https://www.copra.finance/). While access to personal loans is available through banks, there are many contexts in which the only way to get a loan for business is through informal lenders (read: loan sharks). For folks who choose to work and invoice in cryptocurrency, access to even simple legacy financial tools like personal or small business loans can be an obstacle. For his Fellowship, Brian will focus on researching the needs and realities of the growing demographic of workers and small businesses who use crypto as a primary means of invoicing and bookkeeping.
-
 ## [Interview at Devconnect 2023](https://youtu.be/7W0EU9Qsu1Y?si=V6omURU5MijzUPxe)
 
-Listen to Brian's interview [here](

--- a/public/content/fellowship/Chuy/index.md
+++ b/public/content/fellowship/Chuy/index.md
@@ -9,16 +9,16 @@ lat: 19.4326
 lon: -99.1332
 image: /content/fellowship/Chuy/chuy-headshot-logo.jpg
 description: Chuy explores government-issued documents on chain in Argentina and other LatAm countries.
+bio: |
+  ## Chuy Cepeda
+
+  **Chuy Cepeda** [(OS.City)](https://os.city/) worked with municipal and national governments to create an Ethereum wallet app in Spanish for citizens, with a vision to one-day hold government-issued documents (like permits and IDs). During the Fellowship Program, he and his team worked with the government of Argentina and created strategies to advance the meaningful adoption of blockchain in the public sector in Latin America. [Read more about Chuy's work here.](https://blog.ethereum.org/2022/06/07/spotlight-on-latam-identity/)
 tags:
   - identity
   - america-latin
   - america-central
   - 2021-cohort-1
 ---
-
-## Chuy Cepeda
-
-**Chuy Cepeda** [(OS.City)](https://os.city/) worked with municipal and national governments to create an Ethereum wallet app in Spanish for citizens, with a vision to one-day hold government-issued documents (like permits and IDs). During the Fellowship Program, he and his team worked with the government of Argentina and created strategies to advance the meaningful adoption of blockchain in the public sector in Latin America. [Read more about Chuy's work here.](https://blog.ethereum.org/2022/06/07/spotlight-on-latam-identity/)
 
 ---
 

--- a/public/content/fellowship/David/index.md
+++ b/public/content/fellowship/David/index.md
@@ -9,14 +9,14 @@ lat: 6.5244
 lon: 3.3792
 image: /content/fellowship/David/david-headshot.jpg
 description: David is documenting the nuts and bolts of running a node in Nigeria and, more generally, on the African continent and all the challenges that come with it.
+bio: |
+  ## David Uzochukwu
+
+  Running an Ethereum node in Africa faces challenges such as limited internet connectivity, high data costs, inconsistent power supply, and lack of education, all of which can hinder consistent operation. However, it presents significant opportunities for local innovation, improved financial inclusion, and participation in the global blockchain ecosystem, particularly as infrastructure continues to improve. David will be researching and documenting what it takes for Ethereum to be a decentralized world computer where everyone, independently of their location, can play a role in ensuring its geographical spread and robustness.
 tags:
   - 2024-cohort-4
   - Africa-west
 ---
-
-## David Uzochukwu
-
-Running an Ethereum node in Africa faces challenges such as limited internet connectivity, high data costs, inconsistent power supply, and lack of education, all of which can hinder consistent operation. However, it presents significant opportunities for local innovation, improved financial inclusion, and participation in the global blockchain ecosystem, particularly as infrastructure continues to improve. David will be researching and documenting what it takes for Ethereum to be a decentralized world computer where everyone, independently of their location, can play a role in ensuring its geographical spread and robustness.
 
 ## Socials 
 [Telegram](t.me/nodebridege)

--- a/public/content/fellowship/Devansh/index.md
+++ b/public/content/fellowship/Devansh/index.md
@@ -9,19 +9,17 @@ lat: 12.9716
 lon: 77.5946
 image: /content/fellowship/Devansh/devansh-headshot.jpg
 description: Devansh is exploring retroactive funding for citizen journalists using the hypercerts standard.
+bio: |
+  ## Devansh Mehta
+
+  Devansh Mehta, co-founder of [VoiceDeck](https://voicedeck.org/), is interested in mapping out public good impact space. Impact methodologies and markets for environmental use cases are well-documented mechanisms, but sometimes 'impact' wanders into more subjective territory: Investigative journalism, for example, is undoubtedly a public good. How can the real work of journalists be documented and valued in a way that fits into the right funding mechanism? Devansh will work with citizen journalism newsrooms to explore methodologies of impact documentation using the [hypercerts standard](https://hypercerts.org/), with an aim to find a good mechanism of retroactive funding for positive social outcomes.
+
+  ### [Interview at Devconnect 2023](https://youtu.be/42ukRSN0-ms?si=4T4ud4CDUmIkPsii)
 tags:
   - asia-south
   - impact
   - funding
   - 2023-cohort-3
----
-
-## Devansh Mehta
-
-Devansh Mehta, co-founder of [VoiceDeck](https://voicedeck.org/), is interested in mapping out public good impact space. Impact methodologies and markets for environmental use cases are well-documented mechanisms, but sometimes ‘impact’ wanders into more subjective territory: Investigative journalism, for example, is undoubtedly a public good. How can the real work of journalists be documented and valued in a way that fits into the right funding mechanism? Devansh will work with citizen journalism newsrooms to explore methodologies of impact documentation using the [hypercerts standard](https://hypercerts.org/), with an aim to find a good mechanism of retroactive funding for positive social outcomes.
-
-### [Interview at Devconnect 2023](https://youtu.be/42ukRSN0-ms?si=4T4ud4CDUmIkPsii)
-
 ---
 
 # **Piloting Journalism Impact Certificates, a new blockspace frontier**

--- a/public/content/fellowship/Devansh/index.md
+++ b/public/content/fellowship/Devansh/index.md
@@ -48,7 +48,7 @@ Think of the experience of buying a t-shirt: you go to a shop, inspect the quali
 
 The idea of impact certificates was first brought up in 2014 by Paul Christiano on the Effective Altruism forum. He saw it as a coordination mechanism, bringing together people with the ability to undertake a project, means to fund it, and knowledge to evaluate it, premised around creating positive feedback loops between impact creation and revenue generation.
 
-![Funding Flywheel with Impact Certificates](https://storage.googleapis.com/ethereum-hackmd/upload_39d68f98054e596978ae20bbfc754f7e.png)]
+![Funding Flywheel with Impact Certificates](https://storage.googleapis.com/ethereum-hackmd/upload_39d68f98054e596978ae20bbfc754f7e.png)
 
 Even back then, Paul [proposed](https://paulfchristiano.medium.com/certificates-of-impact-34fa4621481e) the use of a blockchain to solve the issue of double spending, where the same impact might be sold multiple times. However, it wasn’t until [Hypercerts](https://www.hypercerts.org/)—digital tokens that represent the impact of some work—launched last year that a clear standard for impact certificates came into existence.
 

--- a/public/content/fellowship/Eddie/index.md
+++ b/public/content/fellowship/Eddie/index.md
@@ -9,13 +9,13 @@ lat: -1.2922
 lon: 36.8218
 image: /content/fellowship/Eddie/eddie-headshot.jpg
 description: Eddie's Antugrow platform digitizes farmer production records and farm metadata to create reputation scores on-chain, with a goal to access to affordable working capital for smallholder farmers and cooperatives in Kenya
+bio: |
+  ## Eddie Kago
+
+  Eddie, founded [Antugrow](https://antugrow.com/) to help farmer cooperatives modernize their post-harvest record-keeping while creating on-chain credit scores for smallholder farmers in Kenya. By standardizing farmer data for interoperability purposes, Eddie aims to unlock low-cost credit and scalable agricultural insurance, leveraging his expertise in building digital identities within the agricultural development context. Antugrow intends to provide a human friendly stack to getting farmers onchain to enable economic prosperity.
 tags:
   - defi
   - 2024-cohort-4
   - africa-east
   - farmers
 ---
-
-## Eddie Kago
-
-Eddie, founded [Antugrow](https://antugrow.com/) to help farmer cooperatives modernize their post-harvest record-keeping while creating on-chain credit scores for smallholder farmers in Kenya. By standardizing farmer data for interoperability purposes, Eddie aims to unlock low-cost credit and scalable agricultural insurance, leveraging his expertise in building digital identities within the agricultural development context. Antugrow intends to provide a human friendly stack to getting farmers onchain to enable economic prosperity.

--- a/public/content/fellowship/Gabriela/index.md
+++ b/public/content/fellowship/Gabriela/index.md
@@ -9,15 +9,15 @@ lat: 25.6866
 lon: -100.3161
 image: /content/fellowship/Gabriela/gabriela-headshot.jpg
 description: Bloinx is a project that focuses on 'tandas' in Mexico. In 2022, Gabriela conducted user research with several women's saving circles, and ran a pilot of Bloinx deployed on the polygon and celo side-chains.
+bio: |
+  ## Gabriela Guerra
+
+  **Gabriela Guerra** founded [Bloinx](https://bloinx.io/), a startup that implements blockchain-based tandas (also known as cundinas, susu, hui, arisan, quiniela, stokvel, and others around the world) – informal savings circles. Gabriela is convinced that blockchain can have real benefit for the unbanked population of the world, and that savings circles are one good starting mechanism. During her Fellowship, Gabriela conducted pilots in Mexico and Venezuela and used the research to help improve Bloinx for larger scales.
 tags:
   - america-latin
   - 2022-cohort-2
   - defi
   - research
 ---
-
-## Gabriela Guerra
-
-**Gabriela Guerra** founded [Bloinx](https://bloinx.io/), a startup that implements blockchain-based tandas (also known as cundinas, susu, hui, arisan, quiniela, stokvel, and others around the world) – informal savings circles. Gabriela is convinced that blockchain can have real benefit for the unbanked population of the world, and that savings circles are one good starting mechanism. During her Fellowship, Gabriela conducted pilots in Mexico and Venezuela and used the research to help improve Bloinx for larger scales.
 
 ### [Interview at Devcon6 2022](https://youtu.be/JVIi0t6JLcQ?si=sbQuMIya61KIFgkR)

--- a/public/content/fellowship/Guo/index.md
+++ b/public/content/fellowship/Guo/index.md
@@ -9,6 +9,10 @@ lat: 40.7128
 lon: -74.006
 image: /content/fellowship/Guo/guo-headshot.jpg
 description: Guo is building a new form of sustainable funding for content creators, using a Harberger tax (plural ownership) mechanism.
+bio: |
+  ## Guo
+
+  Guo Liu's project combines advertisement protocols and quadratic funding on [Matters Town](https://matters.town/) to support high-quality open-access content. By using advertisement revenue as a matching fund, the project aims to democratize support for content creators, drawing on Guo's experience in building decentralized digital public spaces and his commitment to freedom of information. MattersTown is widely used by content creators around the world (predominance of Chinese-speaking, Russian, and Korean). It is experimenting with a new way to fund journalism and content creation.
 tags:
   - asia
   - 2024-cohort-4
@@ -16,10 +20,6 @@ tags:
   - funding
   - UnitedStates
 ---
-
-## Guo
-
-Guo Liu's project combines advertisement protocols and quadratic funding on [Matters Town](https://matters.town/) to support high-quality open-access content. By using advertisement revenue as a matching fund, the project aims to democratize support for content creators, drawing on Guo's experience in building decentralized digital public spaces and his commitment to freedom of information. MattersTown is widely used by content creators around the world (predominance of Chinese-speaking, Russian, and Korean). It is experimenting with a new way to fund journalism and content creation.
 
 ## Billboard Protocol
 

--- a/public/content/fellowship/Karam/index.md
+++ b/public/content/fellowship/Karam/index.md
@@ -9,6 +9,10 @@ lat: 35.3292
 lon: 40.135
 image: /content/fellowship/Karam/karam-headshot.jpg
 description: Beyond Borders - Unveiling Potential of Blockchain in a Crisis - the case of Syria
+bio: |
+  ## Karam Alhamad
+
+  **Karam Alhamad** is an entrepreneur, fintech visionary, international development professional, and human rights policy advocate. Karam founded [ZeFi,](https://zefi.com/en) an educational platform and community focused on fostering blockchain education and research custom-fit for the Syrian context. For the Fellowship, Karam conducted research that increases practical and culturally-sensitive understandings of how blockchains can solve problems in conflict settings.
 tags:
   - middle-east
   - p2p
@@ -19,10 +23,6 @@ tags:
   - 2022-cohort-2
   - human-rights
 ---
-
-## Karam Alhamad
-
-**Karam Alhamad** is an entrepreneur, fintech visionary, international development professional, and human rights policy advocate. Karam founded [ZeFi,](https://zefi.com/en) an educational platform and community focused on fostering blockchain education and research custom-fit for the Syrian context. For the Fellowship, Karam conducted research that increases practical and culturally-sensitive understandings of how blockchains can solve problems in conflict settings.
 
 ---
 

--- a/public/content/fellowship/Kuldeep/index.md
+++ b/public/content/fellowship/Kuldeep/index.md
@@ -9,6 +9,10 @@ lat: 23.685
 lon: 90.3563
 image: /content/fellowship/Kuldeep/kuldeep-headshot.jpg
 description: How should the world's largest NGO approach decentralized technology?
+bio: |
+  ## Kuldeep Bandhu Aryal
+
+  **Kuldeep Bandhu Aryal** [(BRAC)](http://www.brac.net/) sought to build a blockchain and crypto strategy for BRAC - the world's largest NGO based in Bangladesh that annually serves over 100 million people. His project - which also involves multiple experiments using blockchain - could serve as a model for other social enterprises and the development sector at large.
 tags:
   - asia-south
   - asia
@@ -16,9 +20,5 @@ tags:
   - NGO
   - 2021-cohort-1
 ---
-
-## Kuldeep Bandhu Aryal
-
-**Kuldeep Bandhu Aryal** [(BRAC)](http://www.brac.net/) sought to build a blockchain and crypto strategy for BRAC - the world’s largest NGO based in Bangladesh that annually serves over 100 million people. His project - which also involves multiple experiments using blockchain - could serve as a model for other social enterprises and the development sector at large.
 
 ### [Interview at Devconnect 2023](https://youtu.be/yhoAygTNsls?si=4wUTfOsyt1zRNtKB)

--- a/public/content/fellowship/Lefteris/index.md
+++ b/public/content/fellowship/Lefteris/index.md
@@ -9,14 +9,13 @@ lat: 37.9838
 lon: 23.7275
 image: /content/fellowship/Lefteris/lefteris-headshot.jpg
 description: Lefteris is focused on reducing marine plastic pollution by engaging with fishers in Greece and the Mediterranean and adopting cleaning and sustainability practices.
+bio: |
+  ## Lefteris Arapakis
+
+  Lefteris was born into a family with a deep-rooted tradition in the fishing industry. In 2016, he founded [Enaleia](https://enaleia.com/) to engage fishers in addressing the social and environmental challenges of ocean degradation.
+  Lefteris began by educating fishers on sustainable practices and integrating collected waste into a circular economy, focusing on the plastics value chain in Greece. His initiative quickly expanded to encompass the entire Mediterranean Sea. A key aspect of Enaleia's work is tracking the lifecycle of ocean-collected plastic, and as part of his Fellowship, Lefteris will transition the platform into a public chain and explore other blockchain-related verticals into Eneleia.
 tags:
   - 2024-cohort-4
   - europe
   - climate
 ---
-
-## Lefteris Arapakis
-
-Lefteris was born into a family with a deep-rooted tradition in the fishing industry. In 2016, he founded [Enaleia](https://enaleia.com/) to engage fishers in addressing the social and environmental challenges of ocean degradation.
-Lefteris began by educating fishers on sustainable practices and integrating collected waste into a circular economy, focusing on the plastics value chain in Greece. His initiative quickly expanded to encompass the entire Mediterranean Sea. A key aspect of Enaleia's work is tracking the lifecycle of ocean-collected plastic, and as part of his Fellowship, Lefteris will transition the platform into a public chain and explore other blockchain-related verticals into Eneleia.
-

--- a/public/content/fellowship/Marcus/index.md
+++ b/public/content/fellowship/Marcus/index.md
@@ -9,16 +9,16 @@ lat: 14.6349
 lon: -90.5069
 image: /content/fellowship/Marcus/marcus-headshot.jpg
 description: Empowering disenfranchised communities in Latin America using Ethereum
+bio: |
+  ## Marcus Alburez Myers
+
+  **Marcus Alburez Myers** is a Guatemalan entrepreneur working to address today's pressing challenges. He is currently a Founder-in-Residence at Europe's leading accelerator, Entrepreneur First, where he is drawing on the power of web3 to empower marginalized communities. With a focus in Guatemala, Marcus explored the real-world barriers to physical asset financing for DeFi, and compiled his finding into the ["Last Mile DeFi Report"](https://marcus.mirror.xyz/nFmYxl7DkZF655eCFz7Z4QlrOZ5ycg7Ny5gDcMpQ-tQ).
 tags:
   - america-latin
   - defi
   - research
   - 2022-cohort-2
 ---
-
-## Marcus Alburez Myers
-
-**Marcus Alburez Myers** is a Guatemalan entrepreneur working to address today's pressing challenges. He is currently a Founder-in-Residence at Europe's leading accelerator, Entrepreneur First, where he is drawing on the power of web3 to empower marginalized communities. With a focus in Guatemala, Marcus explored the real-world barriers to physical asset financing for DeFi, and compiled his finding into the ["Last Mile DeFi Report"](https://marcus.mirror.xyz/nFmYxl7DkZF655eCFz7Z4QlrOZ5ycg7Ny5gDcMpQ-tQ).
 
 ---
 

--- a/public/content/fellowship/Masa/index.md
+++ b/public/content/fellowship/Masa/index.md
@@ -9,14 +9,14 @@ lat: 35.6895
 lon: 139.6917
 image: /content/fellowship/Masa/masa-headshot.jpg
 description: Ongaeshi is exploring retroactive solidarity payments in education and employment.
+bio: |
+  ## Masahiro Fukuhara
+
+  Masahiro (Masa) Fukuhara wants to spread the spirit of ONGAESHI, (恩返し, "To return a favor") in the world of education. [ONGAESHI DAO](https://www.lp.ongaeshi-pj.jp/en) is exploring mechanisms of retroactive solidarity payments in education and employment. For his Fellowship, Masa and other ONGAESHI DAO team members will learn from pilot programs in which contributors to the public good of education like funders and teachers are rewarded when businesses hire their students.
 tags:
   - asia
   - education
   - 2023-cohort-3
 ---
-
-## Masahiro Fukuhara
-
-Masahiro (Masa) Fukuhara wants to spread the spirit of ONGAESHI, (恩返し, "To return a favor") in the world of education. [ONGAESHI DAO](https://www.lp.ongaeshi-pj.jp/en) is exploring mechanisms of retroactive solidarity payments in education and employment. For his Fellowship, Masa and other ONGAESHI DAO team members will learn from pilot programs in which contributors to the public good of education like funders and teachers are rewarded when businesses hire their students.
 
 ### [Interview at Devconnect 2023](https://youtu.be/NiT5kUfnPc8?si=s_tK_gkzMjNJOkPh)

--- a/public/content/fellowship/Mercedes/index.md
+++ b/public/content/fellowship/Mercedes/index.md
@@ -9,6 +9,10 @@ lat: 10.4806
 lon: -66.9036
 image: /content/fellowship/Mercedes/mercedes-headshot.jpg
 description: Mercedes' research focuses on understanding the impact of crypto in Venezuela through the lenses of human experiences and how this can help us creare Web3 solutions to strengthen civil organizations in Venezuela
+bio: |
+  ## Mercedes Rodriguez Simon
+
+  Mercedes' project explores the impact of crypto usage on overcoming hyperinflation and devaluation in Venezuela's national economy and the experiences of small communities and project grantees currently using crypto donation platforms to fund non-governmental initiatives.
 tags:
   - 2024-cohort-4
   - america-latin
@@ -16,9 +20,5 @@ tags:
   - human-rights
   - NGO
 ---
-
-## Mercedes Rodriguez Simon
-
-Mercedes' project explores the impact of crypto usage on overcoming hyperinflation and devaluation in Venezuela’s national economy and the experiences of small communities and project grantees currently using crypto donation platforms to fund non-governmental initiatives.
 
 > Read an Interview with Mercedes on the [ETHKipu blog](https://www.ethkipu.org/en/blog/interview-with-mercedes-rodriguez)

--- a/public/content/fellowship/Mihajlo/index.md
+++ b/public/content/fellowship/Mihajlo/index.md
@@ -8,7 +8,11 @@ country: Serbia
 lat: 44.7866
 lon: 20.4489
 image: /content/fellowship/Mihajlo/mihajlo-headshot.jpg
-description: The scouting movement is decentralised by nature and community-driven by essence. They are working on a Scout’s passport on chain, onboarding youth all over the world.
+description: The scouting movement is decentralised by nature and community-driven by essence. They are working on a Scout's passport on chain, onboarding youth all over the world.
+bio: |
+  ## **Mihajlo Atanackovic**
+
+  **Mihajlo Atanackovic** is leading the digital transformation journey of one of the world's biggest non-formal educational youth movements - the [World Organization of the Scout Movement](https://www.scout.org/) with 57+ million members from around the globe. To get the Scout Movement ready for web3, he is embarking on an ambitious project involving digitalising badges, exploring DAOs for different levels of the Movement, and how the scouts might employ novel coordination mechanisms for grassroots organization. You can read more about Mihajlo's work [in this blogpost.](https://blog.ethereum.org/2023/05/01/scouting-future-movement)
 tags:
   - identity
   - europe-east
@@ -16,10 +20,6 @@ tags:
   - 2022-cohort-2
   - global
 ---
-
-## **Mihajlo Atanackovic**
-
-**Mihajlo Atanackovic** is leading the digital transformation journey of one of the world's biggest non-formal educational youth movements - the [World Organization of the Scout Movement](https://www.scout.org/) with 57+ million members from around the globe. To get the Scout Movement ready for web3, he is embarking on an ambitious project involving digitalising badges, exploring DAOs for different levels of the Movement, and how the scouts might employ novel coordination mechanisms for grassroots organization. You can read more about Mihajlo's work [in this blogpost.](https://blog.ethereum.org/2023/05/01/scouting-future-movement)
 
 ---
 

--- a/public/content/fellowship/Mulenga/index.md
+++ b/public/content/fellowship/Mulenga/index.md
@@ -9,16 +9,16 @@ lat: -15.3875
 lon: 28.3228
 image: /content/fellowship/Mulenga/mulenga-headshot.jpg
 description: Mulenga is developing a tokenized artifact registry and experimenting with museum revenue sharing for community documentation of art, customs, and crafting practices.
+bio: |
+  ## Mulenga Kapwepwe
+
+  Mulenga Kapwepwe is co-founder of the Women's History Museum of Zambia. There are many African artifacts in museums around the world, but rarely do those items have a tangible connection to the people and communities who created them. For her Fellowship, Mulenga is working with the Zambian web3 community to create a tokenized artifact registry, experimenting with museum revenue sharing for community documentation of art, customs, and crafting methodologies still practiced by the descendants of those items on display in museums around the world. Even if the items won't return to their places of origin in the near future, it's a small step toward bridging a gap of ownership that spans centuries.
 tags:
   - 2023-cohort-3
   - art-and-culture
   - africa-southern
   - africa
 ---
-
-## Mulenga Kapwepwe
-
-Mulenga Kapwepwe is co-founder of the Women’s History Museum of Zambia. There are many African artifacts in museums around the world, but rarely do those items have a tangible connection to the people and communities who created them. For her Fellowship, Mulenga is working with the Zambian web3 community to create a tokenized artifact registry, experimenting with museum revenue sharing for community documentation of art, customs, and crafting methodologies still practiced by the descendants of those items on display in museums around the world. Even if the items won’t return to their places of origin in the near future, it’s a small step toward bridging a gap of ownership that spans centuries.
 
 ## SummitShare
 

--- a/public/content/fellowship/Naroa/index.md
+++ b/public/content/fellowship/Naroa/index.md
@@ -9,6 +9,10 @@ lat: -1.9499
 lon: 30.0588
 image: /content/fellowship/Naroa/naroa-headshot.jpg
 description: Naroa explores Ethereum-based solutions as part of Giga's effort to connect every school to the internet.
+bio: |
+  ## **Naroa Zurutuza**
+
+  **Naroa Zurutuza** [(Giga)](https://gigaconnect.org/) explored Ethereum-based solutions as part of Giga's effort to connect every school to the internet. By helping to provide today's most important public good to billions of currently unconnected people, Naroa envisioned many roles that blockchain can play, from increasing accountability of service providers and financing connectivity infrastructures to an access point to the global economy and marketplaces.
 tags:
   - 2021-cohort-1
   - global
@@ -16,7 +20,3 @@ tags:
   - africa
   - africa-east
 ---
-
-## **Naroa Zurutuza**
-
-**Naroa Zurutuza** [(Giga)](https://gigaconnect.org/) explored Ethereum-based solutions as part of Giga's effort to connect every school to the internet. By helping to provide today’s most important public good to billions of currently unconnected people, Naroa envisioned many roles that blockchain can play, from increasing accountability of service providers and financing connectivity infrastructures to an access point to the global economy and marketplaces.

--- a/public/content/fellowship/Rebecca/index.md
+++ b/public/content/fellowship/Rebecca/index.md
@@ -9,12 +9,12 @@ lat: -34.1281
 lon: 18.3371
 image: /content/fellowship/Rebecca/rebecca-headshot.jpg
 description: Commitment pooling, local currency, and indigenous mutual aid practices.
+bio: |
+  ## Rebecca Mqamelo
+
+  Rebecca's research explores the integration of EVM-based local currencies with traditional economic practices in Africa. Her study will analyze ERC20-based local currency models, comparing (1) traditional digital vouchers where they are backed by a government body or money and (2) an emergent, potentially transformative model where the community pools their future production capacity as commitment. How does tokenizing social contracts redefine our understanding of the function of money in a community? What are the underlying protocols that sustain non-monetary, indigenous practices of resource coordination? And how can these protocols find new expression in decentralized technology, transforming inherited systems into powerful tools for ecological sustainability, cooperation and mutual care? In an attempt to answer these questions, the project will focus on communities in Kenya and South Africa that are reviving their customs through [Grassroots Economics' Sarafu Network](https://grassrootseconomics.org/pages/sarafu-network), which also offers 6+ years of onchain data.
 tags:
   - defi
   - 2024-cohort-4
   - africa-southern
 ---
-
-## Rebecca Mqamelo
-
-Rebecca's research explores the integration of EVM-based local currencies with traditional economic practices in Africa. Her study will analyze ERC20-based local currency models, comparing (1) traditional digital vouchers where they are backed by a government body or money and (2) an emergent, potentially transformative model where the community pools their future production capacity as commitment. How does tokenizing social contracts redefine our understanding of the function of money in a community? What are the underlying protocols that sustain non-monetary, indigenous practices of resource coordination? And how can these protocols find new expression in decentralized technology, transforming inherited systems into powerful tools for ecological sustainability, cooperation and mutual care? In an attempt to answer these questions, the project will focus on communities in Kenya and South Africa that are reviving their customs through [Grassroots Economics’ Sarafu Network](https://grassrootseconomics.org/pages/sarafu-network), which also offers 6+ years of onchain data.

--- a/public/content/fellowship/Tomislav/index.md
+++ b/public/content/fellowship/Tomislav/index.md
@@ -9,12 +9,12 @@ lat: 43.5081
 lon: 16.4402
 image: /content/fellowship/Tomislav/tomislav-headshot.jpg
 description: MUQA - Municipal Quadratic Funding Initiative
+bio: |
+  ## Tomislav Mamić
+
+  Tomislav or "Tomo," from Croatia, is working on the Municipal Quadratic Funding Initiative ([Muqa](https://muqa.org/)). In its broader purpose of onboarding institutions to Ethereum, Muqa team has built and maintains [Zazelenimo](https://zazelenimo.com) - a participatory budgeting application with Quadratic Funding and Ethereum accounts included. This will allow cities to both engage their citizens and fundraise from them for public goods. Visit Muqa site or join their [community](https://t.me/muqaorg) to learn more and engage.
 tags:
   - europe
   - 2024-cohort-4
   - funding
 ---
-
-## Tomislav Mamić
-
-Tomislav or “Tomo,” from Croatia, is working on the Municipal Quadratic Funding Initiative ([Muqa](https://muqa.org/)). In its broader purpose of onboarding institutions to Ethereum, Muqa team has built and maintains [Zazelenimo](https://zazelenimo.com) - a participatory budgeting application with Quadratic Funding and Ethereum accounts included. This will allow cities to both engage their citizens and fundraise from them for public goods. Visit Muqa site or join their [community](https://t.me/muqaorg) to learn more and engage.

--- a/public/content/fellowship/Valeriia/index.md
+++ b/public/content/fellowship/Valeriia/index.md
@@ -9,16 +9,14 @@ lat: 50.4501
 lon: 30.5234
 image: /content/fellowship/Valeriia/valeriia-headshot.jpg
 description: Studying and documenting grassroots adoption of blockchain and other decentralized applications within the Ukrainian community
+bio: |
+  ## Valeriia Panina
+
+  Riia is a user experience specialist and an advisor to the Ukraine's Ministry of Digital Transformation. The war in Ukraine has shown that ingenuity and tenacity in human coordination is essential. Valeriia took on a user research project for her fellowship in order to better contextualize crypto in the war. Through dozens of interviews, Riia sought to understand the real drivers and blockers of adoption for ordinary users in Ukraine. [The full research report](https://uadoption.super.site/) is available to read, and what follows is a personal reflection of her work and its context.
 tags:
   - research
   - europe
   - 2023-cohort-3
----
-
-## Valeriia Panina
-
-Riia is a user experience specialist and an advisor to the Ukraine's Ministry of Digital Transformation. The war in Ukraine has shown that ingenuity and tenacity in human coordination is essential. Valeriia took on a user research project for her fellowship in order to better contextualize crypto in the war. Through dozens of interviews, Riia sought to understand the real drivers and blockers of adoption for ordinary users in Ukraine. [The full research report](https://uadoption.super.site/) is available to read, and what follows is a personal reflection of her work and its context. 
-
 ---
 ### A Happy New Year
 

--- a/src/components/Md/MdComponents.tsx
+++ b/src/components/Md/MdComponents.tsx
@@ -26,23 +26,23 @@ const Header1 = (props) => {
 }
 
 const Header2 = (props) => {
-  return <H2 variant="action" {...props} mt={20} />
+  return <H2 variant="action" {...props} mt={32} />
 }
 
 const Header3 = (props) => {
-  return <H3 variant="action" {...props} mt={12} />
+  return <H3 variant="action" {...props} mt={24} />
 }
 
 const Header4 = (props) => {
-  return <H4 variant="action" {...props} mt={8} />
+  return <H4 variant="action" {...props} mt={16} />
 }
 
 const Header5 = (props) => {
-  return <H5 variant="action" {...props} />
+  return <H5 variant="action" {...props} mt={12} />
 }
 
 const Header6 = (props) => {
-  return <H6 variant="action" {...props} />
+  return <H6 variant="action" {...props} mt={8} />
 }
 
 const Paragraph = (props) => {

--- a/src/components/Md/MdComponents.tsx
+++ b/src/components/Md/MdComponents.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Divider,
+  Heading,
   ListItem,
   OrderedList,
   Text,
@@ -12,19 +13,28 @@ import Link from "@/components/Link"
 import MarkdownImage from "@/components/Md/MarkdownImage"
 
 const Header1 = (props) => {
-  return <H1 variant="action" {...props} />
+  return (
+    <Heading
+      as="h1"
+      textStyle="h1"
+      fontSize={{ base: "32", md: "48" }}
+      wordBreak="break-word"
+      variant="action"
+      {...props}
+    />
+  )
 }
 
 const Header2 = (props) => {
-  return <H2 variant="action" {...props} mt={16} />
+  return <H2 variant="action" {...props} mt={20} />
 }
 
 const Header3 = (props) => {
-  return <H3 variant="action" {...props} />
+  return <H3 variant="action" {...props} mt={12} />
 }
 
 const Header4 = (props) => {
-  return <H4 variant="action" {...props} />
+  return <H4 variant="action" {...props} mt={8} />
 }
 
 const Header5 = (props) => {
@@ -36,7 +46,7 @@ const Header6 = (props) => {
 }
 
 const Paragraph = (props) => {
-  return <Text textStyle="base-text" {...props} />
+  return <Text textStyle="base-text" mb={4} {...props} />
 }
 
 const ListItemStyled = (props) => {

--- a/src/layouts/FellowLayout.tsx
+++ b/src/layouts/FellowLayout.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex, Image } from "@chakra-ui/react"
+import { Box, Flex, Image, Divider } from "@chakra-ui/react"
+import { MDXRemote } from "next-mdx-remote"
 
 import ContentContainer from "@/components/ContentContainer"
 import FellowLayoutHero from "@/components/Heroes/FellowLayoutHero"
@@ -6,6 +7,7 @@ import { MARKDOWN_CONTENT_MAX_WIDTH } from "@/utils/constants"
 import TableOfContents from "@/components/TableOfContents"
 import { H3 } from "@/components/Headings"
 import FellowCard from "@/components/FellowCard"
+import MdComponents from "@/components/Md/MdComponents"
 
 export const FellowLayout = ({
   children,
@@ -13,7 +15,7 @@ export const FellowLayout = ({
   tocItems,
   allFellowsFrontmatter,
 }) => {
-  const { index, title, fellowName, country, tags, image } = frontmatter
+  const { index, title, fellowName, country, tags, image, bio, bioSource } = frontmatter
 
   const meetMoreFellows = [
     allFellowsFrontmatter[
@@ -39,12 +41,39 @@ export const FellowLayout = ({
           tags={tags}
           image={image}
         />
+        {/* Bio section */}
+        {bioSource && (
+          <Box
+            px={{ base: 6, md: 16 }}
+            pt={4}
+            pb={6}
+            className="fellow-bio"
+          >
+            <Box 
+              sx={{ 
+                "h2:first-of-type": { mt: 0 },
+                "p, li": { fontSize: "sm" },
+                "h2, h3, h4, h5, h6": { fontSize: "md", mb: 2 }
+              }}
+              bg="#00000020"
+              p={6}
+              borderRadius="md"
+              color="body"
+            >
+              <MDXRemote {...bioSource} components={MdComponents as any} />
+            </Box>
+            <Divider mt={8} mb={0} borderColor="divider" />
+          </Box>
+        )}
+        
+        {/* Main content section */}
         <Flex
           px={{ base: 6, md: 16 }}
           gap={16}
-          pt={4}
+          pt={bioSource ? 8 : 4}
           pb={16}
           justifyContent="space-between"
+          className="fellow-story"
         >
           <Box
             w="auto"

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -1,5 +1,6 @@
 import { serialize } from "next-mdx-remote/serialize"
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote"
+import { ReactNode } from "react"
 
 import remarkGfm from "remark-gfm"
 import { join } from "path"
@@ -61,6 +62,17 @@ export const getStaticProps = async (context) => {
     },
   })
 
+  // Process bio field if it exists in frontmatter
+  let bioSource: MDXRemoteSerializeResult | null = null;
+  if (markdown.frontmatter.bio) {
+    bioSource = await serialize(markdown.frontmatter.bio, {
+      mdxOptions: {
+        remarkPlugins,
+        rehypePlugins,
+      },
+    });
+  }
+
   let tocItems = remapTableOfContents(tocNodeItems, mdxSource.compiledSource)
   
   // Ensure tocItems is a valid array with no undefined values
@@ -68,7 +80,10 @@ export const getStaticProps = async (context) => {
 
   return {
     props: {
-      frontmatter: markdown.frontmatter,
+      frontmatter: {
+        ...markdown.frontmatter,
+        bioSource
+      },
       layout: markdown.frontmatter.layout,
       mdxSource,
       slug,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Center, Flex, Image, Text } from "@chakra-ui/react"
 import Parser from "rss-parser"
+import { Item } from "rss-parser"
 
 import ButtonLink from "@/components/Buttons/ButtonLink"
 import { H2 } from "@/components/Headings"
@@ -18,15 +19,35 @@ export const getStaticProps = async () => {
     },
   })
 
-  const feed = await parser.parseURL(
-    "https://blog.ethereum.org/en/next-billion/feed.xml"
-  )
+  let blogs: (Item & { description?: string })[] = [];
+  try {
+    const feed = await parser.parseURL(
+      "https://blog.ethereum.org/en/next-billion/feed.xml"
+    )
+    blogs = feed.items.slice(0, 4);
+  } catch (error) {
+    console.error("Error fetching RSS feed:", error);
+    // Provide fallback blog data
+    blogs = [
+      {
+        title: "Blog post placeholder",
+        link: "#",
+        pubDate: new Date().toISOString(),
+        content: "",
+        contentSnippet: "",
+        guid: "",
+        isoDate: new Date().toISOString(),
+        description: "Unable to fetch blog posts at this time."
+      }
+    ];
+  }
+  
   const allFellowsFrontmatter = getAllFellowsFrontmatter()
 
   return {
     props: {
       allFellowsFrontmatter,
-      blogs: feed.items.slice(0, 4),
+      blogs,
     },
   }
 }


### PR DESCRIPTION
This adds an optional term to the fellow's frontmatter, where the "**bio:**" section is a blacked out box that sits above any markdown content put in by the fellow. Partially addresses issue #171 but does not implement anything fancy with the blog post

Before merging:
- [x] change all fellow bio sections to be in the box 
- [ ] test with mobile
